### PR TITLE
fix: correct '(Skill) Learned' to '(Skills) Learned' in ch02.md

### DIFF
--- a/ebook/markdown/volume1/ch02.md
+++ b/ebook/markdown/volume1/ch02.md
@@ -26,7 +26,7 @@ This chapter is primarily based on the ontology construction sections from Micha
 - [2.12 Early Modeling Discipline](#212-early-modeling-discipline)
 - [2.13 The Emerging Semantic Architecture Mindset](#213-the-emerging-semantic-architecture-mindset)
 - [2.14 Chapter 02 Summary](#214-chapter-02-summary)
-- [2.15 Protégé Operations (Skill) Learned](#215-protégé-operations-skill-learned)
+- [2.15 Protégé Operations (Skills) Learned](#215-protégé-operations-skill-learned)
 - [2.16 EKA Connection](#216-eka-connection)
 - [2.17 Knowledge Graph Perspective](#217-knowledge-graph-perspective)
 - [2.18 Key Concepts](#218-key-concepts)
@@ -520,7 +520,7 @@ Protégé was introduced not simply as a modeling tool, but as a semantic engine
 
 The chapter also reinforced the EKA perspective that ontology serves as the semantic transformation layer between enterprise architecture and executable intelligence systems.
 
-## 2.15 Protégé Operations (Skill) Learned
+## 2.15 Protégé Operations (Skills) Learned
 
 During this chapter, you learned how to:
 


### PR DESCRIPTION
Corrects plural form for consistency in section heading 2.15 per issue #44.

- TOC entry: 'Protégé Operations (Skill) Learned' → 'Protégé Operations (Skills) Learned'  
- Section heading: same fix

Both entries now match the plural forms of 'Operations' and 'Learned'.