### PR TITLE
docs(ch05): fix typo 'name class' -> 'named class'

### DIFF
--- a/ebook/markdown/volume1/ch05.md
+++ b/ebook/markdown/volume1/ch05.md
@@ -41,7 +41,7 @@ Named classes, therefore, are the first step toward transforming abstract domain
 
 Creating named classes in Protégé is an intuitive but deliberate process.
 
-After opening the `Classes tab`, you begin by adding each concept as a name class. Unlike earlier placeholder classes, each Named Class is given a **unique, meaningful identifier**, which establishes it as a semantic entity in the ontology. In practice, this involves entering a class name, positioning it appropriately in the hierarchy, and adding labels and comments that clarify its purpose.
+After opening the `Classes tab`, you begin by adding each concept as a named class. Unlike earlier placeholder classes, each Named Class is given a **unique, meaningful identifier**, which establishes it as a semantic entity in the ontology. In practice, this involves entering a class name, positioning it appropriately in the hierarchy, and adding labels and comments that clarify its purpose.
 
 For example, the class `VegetarianPizza` is placed under `Pizza` in the hierarchy. Its label is "Vegetarian Pizza", and a comment might read: "A pizza containing only non-meat toppings, suitable for vegetarian diets."
 


### PR DESCRIPTION
Fix typographical error in Chapter 5.2 line 44: 'a name class' -> 'a named class'.

Closes #51